### PR TITLE
Update ColorPicker API

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		F34FCFA53F49C97A1D4C900798643366 /* Pods-UNUMColorPicker_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-UNUMColorPicker_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		F96FD6712182307500A0672A /* UNUMColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UNUMColorPickerViewController.swift; path = UNUMColorPicker/Classes/UNUMColorPickerViewController.swift; sourceTree = "<group>"; };
 		F96FD6722182307500A0672A /* UNUMColorPickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = UNUMColorPickerViewController.xib; path = UNUMColorPicker/Classes/UNUMColorPickerViewController.xib; sourceTree = "<group>"; };
-		F9F4BB1B21836F1D00AAF4EA /* UNUMColorPickerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UNUMColorPickerViewModel.swift; sourceTree = "<group>"; };
+		F9F4BB1B21836F1D00AAF4EA /* UNUMColorPickerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UNUMColorPickerViewModel.swift; path = UNUMColorPicker/Classes/UNUMColorPickerViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Example/UNUMColorPicker/ViewController.swift
+++ b/Example/UNUMColorPicker/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
         let colorData: [UIColor] = [.white, .black, .blue, .green, .yellow, .red, .cyan, .brown]
 
         //init viewController
-        let colorPickerViewController = UNUMColorPickerViewController(colors: colorData)
+        let colorPickerViewController = UNUMColorPickerViewController(colors: colorData, initialColor: .white)
         colorPickerViewController.delegate = self
 
         // Add to view.
@@ -42,11 +42,11 @@ class ViewController: UIViewController {
 
 //MARK: UNUMColorPickerDelegate
 extension ViewController: UNUMColorPickerDelegate {
-    func save() {
+    func save(_ colorPickerViewController: UNUMColorPickerViewController) {
         print("save delegate function called. This typically would be where you would want to dismiss the colorPicker.")
     }
 
-    func cancel() {
+    func cancel(_ colorPickerViewController: UNUMColorPickerViewController, initialColor: UIColor) {
         print("cancel delegate function called. This typically would be where you would want to both dismiss the colorPicker as well as reset the the color of whatever you set in `didSet` to its original color.")
     }
 

--- a/UNUMColorPicker/Classes/UNUMColorPickerViewController.swift
+++ b/UNUMColorPicker/Classes/UNUMColorPickerViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 
 public protocol UNUMColorPickerDelegate: class {
     func didSet(color: UIColor)
-    func save()
-    func cancel()
+    func save(_ colorPickerViewController: UNUMColorPickerViewController)
+    func cancel(_ colorPickerViewController: UNUMColorPickerViewController, initialColor: UIColor)
 }
 
 public class UNUMColorPickerViewController: UIViewController {
@@ -36,10 +36,10 @@ public class UNUMColorPickerViewController: UIViewController {
     /// - Parameters:
     ///   - colors: The colors the user will be able to select.
     ///   - initiallySelectedColor: optional parameter letting a particular color be chosen. Default is to use the first color of colorData or clear if there are no colors in the array.
-    public convenience init(colors: [UIColor], initiallySelectedColor: UIColor? = nil) {
+    public convenience init(colors: [UIColor], initialColor: UIColor) {
         let bundle = Bundle(for: UNUMColorPickerViewController.self)
         self.init(nibName: "UNUMColorPickerViewController", bundle: bundle)
-        self.viewModel = UNUMColorPickerViewModel(colors: colors, selectedColor: initiallySelectedColor)
+        self.viewModel = UNUMColorPickerViewModel(colors: colors, initialColor: initialColor)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -61,11 +61,11 @@ public class UNUMColorPickerViewController: UIViewController {
     }
 
     @IBAction func saveAction(_ sender: Any) {
-        delegate?.save()
+        delegate?.save(self)
     }
 
     @IBAction func cancelAction(_ sender: Any) {
-        delegate?.cancel()
+        delegate?.cancel(self, initialColor: viewModel.initialColor)
     }
 }
 

--- a/UNUMColorPicker/Classes/UNUMColorPickerViewModel.swift
+++ b/UNUMColorPicker/Classes/UNUMColorPickerViewModel.swift
@@ -11,10 +11,12 @@ import Foundation
 class UNUMColorPickerViewModel {
 
     let colors: [UIColor]
+    let initialColor: UIColor
     var selectedColor: UIColor
 
-    init(colors: [UIColor], selectedColor: UIColor? = nil) {
+    init(colors: [UIColor], initialColor: UIColor) {
         self.colors = colors
-        self.selectedColor = selectedColor ?? colors.first ?? .clear
+        self.initialColor = initialColor
+        self.selectedColor = initialColor
     }
 }


### PR DESCRIPTION
Save and cancel now return the colorPickerViewController itself to make it easy to dismiss. This also ensures that you don't need to hold on to a reference to it, check if it's nil, and only then dismiss it.

Cancel now returns the original color. Otherwise the initial Color would need a reference at the call point. The main reason for returning the value rather than maintaining a reference is that a reference would be complicated. The value there would have to be set everytime the colorPickerVC was initialized, and erased everytime it was dismissed. This could easily lead to various bugs, and returning the original color side-steps all of these issues. State is much simpler this way and less bug-prone.